### PR TITLE
Add opt-in no-count pagination and window grouping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create and activate virtual environment
         run: |
-          uv venv
+          uv venv --clear --python "${pythonLocation}/bin/python"
           source .venv/bin/activate
           which python
           python --version
@@ -83,7 +83,7 @@ jobs:
 
       - name: Create and activate virtual environment
         run: |
-          uv venv
+          uv venv --clear --python "${pythonLocation}/bin/python"
           source .venv/bin/activate
           which python
           python --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Minor Changes
+
+- Add opt-in no-count pagination modes: `pagination.mode = "none"` and
+  `pagination.mode = "has_next"`.
+- Add opt-in grouped window strategy for top-N-per-group queries, with legacy
+  fallback by default.
+
 ## [0.5.2] - 2025-05-21
 
 ### Minor Changes

--- a/docs/source/usage/grouping.rst
+++ b/docs/source/usage/grouping.rst
@@ -247,6 +247,83 @@ Grouped queries have specific pagination semantics:
         limit=10,
     )
 
+Window Grouping Strategy
+------------------------
+
+Grouped queries use the legacy strategy by default. The legacy path first fetches
+group keys and counts, then fetches items for each group.
+
+For top-N-per-group views, opt into the window strategy:
+
+.. code-block:: python
+
+    querymate = Querymate(
+        select=["id", "name", "status"],
+        group_by="status",
+        sort=["-created_at"],
+        grouping={
+            "strategy": "window",
+            "per_group_limit": 50,
+            "per_group_offset": 0,
+        },
+    )
+    result = await querymate.run_grouped_async(db, User)
+
+The window strategy uses SQL window functions to fetch the requested items across
+groups in one query. It supports simple model-field selections, simple field
+grouping, and date-granularity grouping. Relationship selections and relationship
+group fields are unsupported in the first release; they fall back to the legacy
+strategy by default.
+
+Set ``grouping.fallback = "error"`` to fail instead of falling back:
+
+.. code-block:: python
+
+    querymate = Querymate(
+        select=["id", "name", {"posts": ["id", "title"]}],
+        group_by="status",
+        grouping={"strategy": "window", "fallback": "error"},
+    )
+
+Use ``grouping.include_counts = False`` to avoid exact per-group totals. QueryMate
+fetches one extra item per group and returns ``has_next_page`` in each group's
+pagination metadata:
+
+.. code-block:: python
+
+    querymate = Querymate(
+        select=["id", "name", "status"],
+        group_by="status",
+        sort=["id"],
+        grouping={
+            "strategy": "window",
+            "include_counts": False,
+            "per_group_limit": 25,
+        },
+    )
+
+.. code-block:: json
+
+    {
+      "groups": [
+        {
+          "key": "active",
+          "items": [{"id": 1, "name": "Alice", "status": "active"}],
+          "pagination": {
+            "total": null,
+            "page": 1,
+            "size": 25,
+            "pages": null,
+            "previous_page": null,
+            "next_page": 2,
+            "has_next_page": true,
+            "mode": "has_next"
+          }
+        }
+      ],
+      "truncated": false
+    }
+
 When ``MAX_LIMIT`` is Reached
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -312,6 +389,5 @@ Best Practices
 * Use date granularity that matches your use case (don't use ``minute`` if ``day`` suffices)
 * Consider timezone when displaying date-grouped data to users
 * Monitor the ``truncated`` flag and adjust ``limit`` or use filters if frequently truncated
-
 
 

--- a/docs/source/usage/pagination.rst
+++ b/docs/source/usage/pagination.rst
@@ -113,6 +113,74 @@ Field semantics:
 * ``previous_page``: Previous page number or ``null`` on first page
 * ``next_page``: Next page number or ``null`` on last page
 
+Pagination Modes
+----------------
+
+By default, paginated responses use ``pagination.mode = "full"``. This preserves
+the existing behavior: QueryMate fetches the requested page and runs a count query
+to return ``total`` and ``pages``.
+
+For high-frequency views that do not need exact totals, opt into no-count modes
+with the ``pagination`` block:
+
+.. code-block:: python
+
+    # Fetch items only. No count query is executed.
+    querymate = Querymate(
+        select=["id", "name"],
+        limit=25,
+        offset=0,
+        pagination={"mode": "none"},
+    )
+    result = await querymate.run_async_paginated(db, User)
+
+.. code-block:: json
+
+    {
+      "items": [{"id": 1, "name": "John"}],
+      "pagination": {
+        "total": null,
+        "page": 1,
+        "size": 25,
+        "pages": null,
+        "previous_page": null,
+        "next_page": null,
+        "has_next_page": null,
+        "mode": "none"
+      }
+    }
+
+Use ``pagination.mode = "has_next"`` when the UI only needs to know whether
+another page exists. QueryMate fetches ``limit + 1`` rows, trims the extra row,
+and does not run a count query:
+
+.. code-block:: python
+
+    querymate = Querymate(
+        select=["id", "name"],
+        sort=["id"],
+        limit=25,
+        offset=0,
+        pagination={"mode": "has_next"},
+    )
+    result = await querymate.run_async_paginated(db, User)
+
+.. code-block:: json
+
+    {
+      "items": [{"id": 1, "name": "John"}],
+      "pagination": {
+        "total": null,
+        "page": 1,
+        "size": 25,
+        "pages": null,
+        "previous_page": null,
+        "next_page": 2,
+        "has_next_page": true,
+        "mode": "has_next"
+      }
+    }
+
 Methods Summary
 ---------------
 

--- a/querymate/__init__.py
+++ b/querymate/__init__.py
@@ -63,10 +63,12 @@ from .core.filter import TruePredicate as TruePredicate
 from .core.grouping import DateGranularity as DateGranularity
 from .core.grouping import GroupByConfig as GroupByConfig
 from .core.grouping import GroupedResponse as GroupedResponse
+from .core.grouping import GroupingOptions as GroupingOptions
 from .core.grouping import GroupKeyExtractor as GroupKeyExtractor
 from .core.grouping import GroupResult as GroupResult
 from .core.query_builder import JoinType as JoinType
 from .core.query_builder import QueryBuilder as QueryBuilder
+from .core.querymate import PaginationOptions as PaginationOptions
 from .core.querymate import Querymate as Querymate
 from .types import PaginatedResponse as PaginatedResponse
 from .types import PaginationInfo as PaginationInfo

--- a/querymate/core/grouping.py
+++ b/querymate/core/grouping.py
@@ -4,7 +4,7 @@ This module provides support for grouping query results by field values,
 including dynamic date grouping with timezone support.
 """
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -16,7 +16,7 @@ from querymate.core.config import settings
 from querymate.types import PaginationInfo
 
 
-class DateGranularity(str, Enum):
+class DateGranularity(StrEnum):
     """Supported date granularities for grouping."""
 
     YEAR = "year"
@@ -24,6 +24,37 @@ class DateGranularity(str, Enum):
     DAY = "day"
     HOUR = "hour"
     MINUTE = "minute"
+
+
+GroupingStrategy = Literal["legacy", "window"]
+GroupingFallback = Literal["legacy", "error"]
+
+
+class GroupingOptions(BaseModel):
+    """Opt-in grouped query execution controls."""
+
+    strategy: GroupingStrategy = Field(
+        default="legacy",
+        description="Grouped execution strategy. 'legacy' preserves existing behavior.",
+    )
+    include_counts: bool = Field(
+        default=True,
+        description="Include exact per-group totals in grouped pagination metadata.",
+    )
+    per_group_limit: int | None = Field(
+        default=None,
+        ge=1,
+        description="Override the number of items fetched for each group.",
+    )
+    per_group_offset: int | None = Field(
+        default=None,
+        ge=0,
+        description="Override the offset applied within each group.",
+    )
+    fallback: GroupingFallback = Field(
+        default="legacy",
+        description="Fallback behavior when the requested strategy is unsupported.",
+    )
 
 
 # Format strings for each granularity (SQLite strftime format)

--- a/querymate/core/querymate.py
+++ b/querymate/core/querymate.py
@@ -207,7 +207,7 @@ class Querymate(BaseModel):
 
     def _query_payload_json(self) -> str:
         """Serialize query payloads without default-only opt-in config blocks."""
-        payload = self.model_dump(by_alias=True)
+        payload = self.model_dump(by_alias=True, mode="json")
         if self.pagination.mode == "full":
             payload.pop("pagination", None)
         if self.grouping == GroupingOptions():

--- a/querymate/core/querymate.py
+++ b/querymate/core/querymate.py
@@ -1,17 +1,21 @@
 import json
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, cast
 from urllib.parse import quote, unquote, urlencode
 
 from fastapi import Request
 from fastapi.datastructures import QueryParams
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import func
+from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import Session, SQLModel
+from sqlalchemy.orm import Mapper
+from sqlmodel import Session, SQLModel, inspect
 
 from querymate.core.config import settings
 from querymate.core.grouping import (
     GroupByConfig,
     GroupedResponse,
+    GroupingOptions,
     GroupKeyExtractor,
     GroupResult,
 )
@@ -26,6 +30,16 @@ R = TypeVar("R")
 FieldSelection = str | dict[str, list[str]]
 FilterCondition = dict[str, Any]
 GroupByParam = str | dict[str, Any]
+PaginationMode = Literal["full", "none", "has_next"]
+
+
+class PaginationOptions(BaseModel):
+    """Opt-in pagination execution controls."""
+
+    mode: PaginationMode = Field(
+        default="full",
+        description="Pagination mode. 'full' preserves existing count behavior.",
+    )
 
 
 class Querymate(BaseModel):
@@ -120,6 +134,14 @@ class Querymate(BaseModel):
         description="Join type for relationship queries. Options: 'inner' (default), 'left', 'outer'",
         alias=settings.JOIN_TYPE_PARAM_NAME,
     )
+    pagination: PaginationOptions = Field(
+        default_factory=PaginationOptions,
+        description="Opt-in pagination execution controls",
+    )
+    grouping: GroupingOptions = Field(
+        default_factory=GroupingOptions,
+        description="Opt-in grouped query execution controls",
+    )
 
     @classmethod
     def from_qs(cls, query_params: QueryParams) -> "Querymate":
@@ -173,9 +195,7 @@ class Querymate(BaseModel):
         Returns:
             str: The URL-encoded query string.
         """
-        return urlencode(
-            {settings.QUERY_PARAM_NAME: self.model_dump_json(by_alias=True)}
-        )
+        return urlencode({settings.QUERY_PARAM_NAME: self._query_payload_json()})
 
     def to_query_param(self) -> str:
         """Convert the QueryMate instance to a query string.
@@ -183,7 +203,16 @@ class Querymate(BaseModel):
         Returns:
             str: The URL-encoded query string.
         """
-        return quote(self.model_dump_json(by_alias=True))
+        return quote(self._query_payload_json())
+
+    def _query_payload_json(self) -> str:
+        """Serialize query payloads without default-only opt-in config blocks."""
+        payload = self.model_dump(by_alias=True)
+        if self.pagination.mode == "full":
+            payload.pop("pagination", None)
+        if self.grouping == GroupingOptions():
+            payload.pop("grouping", None)
+        return json.dumps(payload, separators=(",", ":"))
 
     def _pagination(self, total: int) -> PaginationInfo:
         """Build a pagination dictionary from current state and total count.
@@ -212,6 +241,27 @@ class Querymate(BaseModel):
             pages=pages,
             previous_page=previous_page,
             next_page=next_page,
+        )
+
+    def _pagination_without_total(
+        self, mode: Literal["none", "has_next"], has_next_page: bool | None
+    ) -> PaginationInfo:
+        """Build pagination metadata for modes that intentionally skip counts."""
+        size = self.limit or settings.DEFAULT_LIMIT
+        offset_val = self.offset or settings.DEFAULT_OFFSET
+        page = (offset_val // size) + 1 if size > 0 else 1
+        previous_page = page - 1 if page > 1 else None
+        next_page = page + 1 if has_next_page else None
+
+        return PaginationInfo(
+            total=None,
+            page=page,
+            size=size,
+            pages=None,
+            previous_page=previous_page,
+            next_page=next_page,
+            has_next_page=has_next_page,
+            mode=mode,
         )
 
     def run_raw(self, db: Session, model: type[T]) -> list[T]:
@@ -297,21 +347,40 @@ class Querymate(BaseModel):
             PaginatedResponse[dict[str, Any]]: Serialized results with pagination metadata.
         """
         query_builder = QueryBuilder(model=model)
+        query_limit = self.limit
+        if self.pagination.mode == "has_next" and query_limit is not None:
+            query_limit = query_limit + 1
+
         query_builder.build(
             select=self.select,
             filter=self.filter,
             sort=self.sort,
-            limit=self.limit,
+            limit=query_limit,
             offset=self.offset,
             join_type=self.join_type,
         )
         data = query_builder.fetch(db, model)
+
+        has_next_page: bool | None = None
+        if self.pagination.mode == "has_next":
+            page_size = self.limit or settings.DEFAULT_LIMIT
+            has_next_page = len(data) > page_size
+            data = data[:page_size]
+
         serialized = query_builder.serialize(data)
-        total = query_builder.count(db)
+
+        if self.pagination.mode == "full":
+            total = query_builder.count(db)
+            pagination = self._pagination(total)
+        else:
+            pagination = self._pagination_without_total(
+                self.pagination.mode,
+                has_next_page,
+            )
 
         return PaginatedResponse(
             items=serialized,
-            pagination=self._pagination(total),
+            pagination=pagination,
         )
 
     async def run_async(
@@ -373,21 +442,40 @@ class Querymate(BaseModel):
             PaginatedResponse[dict[str, Any]]: Serialized results with pagination metadata.
         """
         query_builder = QueryBuilder(model=model)
+        query_limit = self.limit
+        if self.pagination.mode == "has_next" and query_limit is not None:
+            query_limit = query_limit + 1
+
         query_builder.build(
             select=self.select,
             filter=self.filter,
             sort=self.sort,
-            limit=self.limit,
+            limit=query_limit,
             offset=self.offset,
             join_type=self.join_type,
         )
         data = await query_builder.fetch_async(db, model)
+
+        has_next_page: bool | None = None
+        if self.pagination.mode == "has_next":
+            page_size = self.limit or settings.DEFAULT_LIMIT
+            has_next_page = len(data) > page_size
+            data = data[:page_size]
+
         serialized = query_builder.serialize(data)
-        total = await query_builder.count_async(db)
+
+        if self.pagination.mode == "full":
+            total = await query_builder.count_async(db)
+            pagination = self._pagination(total)
+        else:
+            pagination = self._pagination_without_total(
+                self.pagination.mode,
+                has_next_page,
+            )
 
         return PaginatedResponse(
             items=serialized,
-            pagination=self._pagination(total),
+            pagination=pagination,
         )
 
     async def run_raw_async(self, db: AsyncSession, model: type[T]) -> list[T]:
@@ -472,6 +560,18 @@ class Querymate(BaseModel):
             results = querymate.run_grouped(db, Task)
             ```
         """
+        if self.grouping.strategy == "window":
+            return self._run_grouped_window(db, model, dialect=dialect)
+        return self._run_grouped_legacy(db, model, dialect=dialect)
+
+    def _run_grouped_legacy(
+        self,
+        db: Session,
+        model: type[T],
+        *,
+        dialect: Literal["postgresql", "sqlite"] = "postgresql",
+    ) -> dict[str, Any]:
+        """Run the original grouped query strategy."""
         group_config = self._get_group_config()
         extractor = GroupKeyExtractor(dialect=dialect)
 
@@ -486,7 +586,10 @@ class Querymate(BaseModel):
         # Get all distinct group keys with their counts
         group_keys = query_builder.get_distinct_group_keys(db, group_config, extractor)
 
-        per_group_limit = self.limit or settings.DEFAULT_LIMIT
+        per_group_limit = (
+            self.grouping.per_group_limit or self.limit or settings.DEFAULT_LIMIT
+        )
+        per_group_offset = self.grouping.per_group_offset or self.offset or 0
         max_total = settings.MAX_LIMIT
         total_fetched = 0
         truncated = False
@@ -513,7 +616,7 @@ class Querymate(BaseModel):
                 extractor,
                 group_key,
                 limit=effective_limit,
-                offset=self.offset or 0,
+                offset=per_group_offset,
                 join_type=self.join_type,
             )
 
@@ -524,7 +627,7 @@ class Querymate(BaseModel):
             pagination = self._pagination_for_group(
                 total=group_total,
                 limit=per_group_limit,
-                offset=self.offset or 0,
+                offset=per_group_offset,
             )
 
             groups.append(
@@ -583,6 +686,18 @@ class Querymate(BaseModel):
             results = await querymate.run_grouped_async(db, Task)
             ```
         """
+        if self.grouping.strategy == "window":
+            return await self._run_grouped_window_async(db, model, dialect=dialect)
+        return await self._run_grouped_legacy_async(db, model, dialect=dialect)
+
+    async def _run_grouped_legacy_async(
+        self,
+        db: AsyncSession,
+        model: type[T],
+        *,
+        dialect: Literal["postgresql", "sqlite"] = "postgresql",
+    ) -> dict[str, Any]:
+        """Run the original grouped query strategy asynchronously."""
         group_config = self._get_group_config()
         extractor = GroupKeyExtractor(dialect=dialect)
 
@@ -598,7 +713,10 @@ class Querymate(BaseModel):
             db, group_config, extractor
         )
 
-        per_group_limit = self.limit or settings.DEFAULT_LIMIT
+        per_group_limit = (
+            self.grouping.per_group_limit or self.limit or settings.DEFAULT_LIMIT
+        )
+        per_group_offset = self.grouping.per_group_offset or self.offset or 0
         max_total = settings.MAX_LIMIT
         total_fetched = 0
         truncated = False
@@ -623,7 +741,7 @@ class Querymate(BaseModel):
                 extractor,
                 group_key,
                 limit=effective_limit,
-                offset=self.offset or 0,
+                offset=per_group_offset,
                 join_type=self.join_type,
             )
 
@@ -633,7 +751,7 @@ class Querymate(BaseModel):
             pagination = self._pagination_for_group(
                 total=group_total,
                 limit=per_group_limit,
-                offset=self.offset or 0,
+                offset=per_group_offset,
             )
 
             groups.append(
@@ -649,6 +767,256 @@ class Querymate(BaseModel):
 
         response = GroupedResponse(groups=groups, truncated=truncated)
         return response.model_dump()
+
+    def _window_grouping_unsupported_reason(
+        self,
+        group_config: GroupByConfig,
+        dialect: Literal["postgresql", "sqlite"],
+    ) -> str | None:
+        if dialect not in ("postgresql", "sqlite"):
+            return f"grouping.strategy='window' does not support dialect '{dialect}'"
+        if "." in group_config.field:
+            return "grouping.strategy='window' does not support relationship group_by fields yet"
+        if any(isinstance(field, dict) for field in (self.select or [])):
+            return "grouping.strategy='window' does not support relationship select fields yet"
+        if any(isinstance(sort_item, dict) for sort_item in (self.sort or [])):
+            return "grouping.strategy='window' does not support custom value sort dictionaries yet"
+        return None
+
+    def _handle_window_grouping_unsupported(
+        self,
+        reason: str,
+        db: Session,
+        model: type[T],
+        *,
+        dialect: Literal["postgresql", "sqlite"],
+    ) -> dict[str, Any]:
+        if self.grouping.fallback == "legacy":
+            return self._run_grouped_legacy(db, model, dialect=dialect)
+        raise ValueError(
+            f"{reason}; use grouping.fallback='legacy' to run the legacy grouped strategy"
+        )
+
+    async def _handle_window_grouping_unsupported_async(
+        self,
+        reason: str,
+        db: AsyncSession,
+        model: type[T],
+        *,
+        dialect: Literal["postgresql", "sqlite"],
+    ) -> dict[str, Any]:
+        if self.grouping.fallback == "legacy":
+            return await self._run_grouped_legacy_async(db, model, dialect=dialect)
+        raise ValueError(
+            f"{reason}; use grouping.fallback='legacy' to run the legacy grouped strategy"
+        )
+
+    def _window_group_query(
+        self,
+        model: type[T],
+        group_config: GroupByConfig,
+        extractor: GroupKeyExtractor,
+        per_group_limit: int,
+        per_group_offset: int,
+    ) -> tuple[Any, QueryBuilder, int]:
+        query_builder = QueryBuilder(model=model)
+        query_builder.apply_select(self.select, join_type=self.join_type)
+        query_builder.apply_filter(self.filter)
+        query_builder.apply_sort(self.sort)
+
+        selected_field_count = sum(
+            1 for field in query_builder.select if isinstance(field, str)
+        )
+
+        column = query_builder._resolve_column(group_config.field)
+        group_expr = extractor.get_group_key_expression(column, group_config)
+
+        mapper = cast(Mapper, inspect(model))
+        pk_col = next(col for col in mapper.primary_key)
+        order_by = tuple(getattr(query_builder.query, "_order_by_clauses", ()))
+        if not order_by:
+            order_by = (pk_col,)
+
+        row_number_expr = func.row_number().over(
+            partition_by=group_expr,
+            order_by=order_by,
+        )
+        window_columns = [
+            group_expr.label("querymate_group_key"),
+            row_number_expr.label("querymate_group_row_number"),
+        ]
+        if self.grouping.include_counts:
+            window_columns.append(
+                func.count()
+                .over(partition_by=group_expr)
+                .label("querymate_group_total")
+            )
+
+        window_query = query_builder.query.order_by(None).add_columns(*window_columns)
+        window_subquery = window_query.subquery()
+
+        fetch_limit = per_group_limit
+        if not self.grouping.include_counts:
+            fetch_limit += 1
+
+        row_number_col = window_subquery.c.querymate_group_row_number
+        outer_query = (
+            sa_select(*list(window_subquery.c))
+            .where(row_number_col > per_group_offset)
+            .where(row_number_col <= per_group_offset + fetch_limit)
+            .order_by(window_subquery.c.querymate_group_key, row_number_col)
+        )
+        return outer_query, query_builder, selected_field_count
+
+    def _row_values(self, row: Any) -> tuple[Any, ...]:
+        if hasattr(row, "_tuple"):
+            return tuple(row._tuple())
+        return tuple(row)
+
+    def _build_window_grouped_response(
+        self,
+        rows: list[Any],
+        query_builder: QueryBuilder,
+        model: type[T],
+        selected_field_count: int,
+        per_group_limit: int,
+        per_group_offset: int,
+    ) -> dict[str, Any]:
+        grouped_rows: dict[Any, list[tuple[Any, ...]]] = {}
+        group_totals: dict[Any, int] = {}
+
+        for row in rows:
+            values = self._row_values(row)
+            group_key = values[selected_field_count]
+            grouped_rows.setdefault(group_key, []).append(values[:selected_field_count])
+            if self.grouping.include_counts:
+                group_totals[group_key] = int(values[selected_field_count + 2])
+
+        max_total = settings.MAX_LIMIT
+        total_fetched = 0
+        truncated = False
+        groups: list[GroupResult] = []
+
+        for group_key, row_values in grouped_rows.items():
+            if total_fetched >= max_total:
+                truncated = True
+                break
+
+            remaining = max_total - total_fetched
+            effective_limit = min(per_group_limit, remaining)
+            item_rows = row_values[:effective_limit]
+            data = query_builder.reconstruct_objects(item_rows, model)
+            serialized = query_builder.serialize(data)
+            total_fetched += len(serialized)
+
+            if self.grouping.include_counts:
+                pagination = self._pagination_for_group(
+                    total=group_totals[group_key],
+                    limit=per_group_limit,
+                    offset=per_group_offset,
+                )
+            else:
+                pagination = self._pagination_for_group_without_total(
+                    limit=per_group_limit,
+                    offset=per_group_offset,
+                    has_next_page=len(row_values) > per_group_limit,
+                )
+
+            groups.append(
+                GroupResult(
+                    key=str(group_key) if group_key is not None else None,
+                    items=serialized,
+                    pagination=pagination,
+                )
+            )
+
+            if effective_limit < per_group_limit and len(row_values) >= effective_limit:
+                truncated = True
+
+        response = GroupedResponse(groups=groups, truncated=truncated)
+        return response.model_dump()
+
+    def _run_grouped_window(
+        self,
+        db: Session,
+        model: type[T],
+        *,
+        dialect: Literal["postgresql", "sqlite"] = "postgresql",
+    ) -> dict[str, Any]:
+        group_config = self._get_group_config()
+        unsupported_reason = self._window_grouping_unsupported_reason(
+            group_config, dialect
+        )
+        if unsupported_reason is not None:
+            return self._handle_window_grouping_unsupported(
+                unsupported_reason,
+                db,
+                model,
+                dialect=dialect,
+            )
+
+        extractor = GroupKeyExtractor(dialect=dialect)
+        per_group_limit = (
+            self.grouping.per_group_limit or self.limit or settings.DEFAULT_LIMIT
+        )
+        per_group_offset = self.grouping.per_group_offset or self.offset or 0
+        query, query_builder, selected_field_count = self._window_group_query(
+            model,
+            group_config,
+            extractor,
+            per_group_limit,
+            per_group_offset,
+        )
+        rows = list(db.execute(query).all())
+        return self._build_window_grouped_response(
+            rows,
+            query_builder,
+            model,
+            selected_field_count,
+            per_group_limit,
+            per_group_offset,
+        )
+
+    async def _run_grouped_window_async(
+        self,
+        db: AsyncSession,
+        model: type[T],
+        *,
+        dialect: Literal["postgresql", "sqlite"] = "postgresql",
+    ) -> dict[str, Any]:
+        group_config = self._get_group_config()
+        unsupported_reason = self._window_grouping_unsupported_reason(
+            group_config, dialect
+        )
+        if unsupported_reason is not None:
+            return await self._handle_window_grouping_unsupported_async(
+                unsupported_reason,
+                db,
+                model,
+                dialect=dialect,
+            )
+
+        extractor = GroupKeyExtractor(dialect=dialect)
+        per_group_limit = (
+            self.grouping.per_group_limit or self.limit or settings.DEFAULT_LIMIT
+        )
+        per_group_offset = self.grouping.per_group_offset or self.offset or 0
+        query, query_builder, selected_field_count = self._window_group_query(
+            model,
+            group_config,
+            extractor,
+            per_group_limit,
+            per_group_offset,
+        )
+        results = await db.execute(query)
+        return self._build_window_grouped_response(
+            list(results.all()),
+            query_builder,
+            model,
+            selected_field_count,
+            per_group_limit,
+            per_group_offset,
+        )
 
     def _pagination_for_group(
         self, total: int, limit: int, offset: int
@@ -678,4 +1046,24 @@ class Querymate(BaseModel):
             pages=pages,
             previous_page=previous_page,
             next_page=next_page,
+        )
+
+    def _pagination_for_group_without_total(
+        self, limit: int, offset: int, has_next_page: bool
+    ) -> PaginationInfo:
+        """Build per-group pagination metadata without exact counts."""
+        size = limit
+        page = (offset // size) + 1 if size > 0 else 1
+        previous_page = page - 1 if page > 1 else None
+        next_page = page + 1 if has_next_page else None
+
+        return PaginationInfo(
+            total=None,
+            page=page,
+            size=size,
+            pages=None,
+            previous_page=previous_page,
+            next_page=next_page,
+            has_next_page=has_next_page,
+            mode="has_next",
         )

--- a/querymate/types.py
+++ b/querymate/types.py
@@ -1,8 +1,8 @@
 """Type definitions for Querymate responses."""
 
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_serializer
 
 T = TypeVar("T")
 
@@ -10,12 +10,23 @@ T = TypeVar("T")
 class PaginationInfo(BaseModel):
     """Pagination metadata for query results."""
 
-    total: int
+    total: int | None
     page: int
     size: int
-    pages: int
+    pages: int | None
     previous_page: int | None = None
     next_page: int | None = None
+    has_next_page: bool | None = None
+    mode: str | None = None
+
+    @model_serializer(mode="wrap")
+    def serialize_legacy_shape(self, handler: Any) -> dict[str, Any]:
+        """Keep legacy payloads from gaining new pagination fields."""
+        data = handler(self)
+        if self.mode is None:
+            data.pop("mode", None)
+            data.pop("has_next_page", None)
+        return cast(dict[str, Any], data)
 
 
 class PaginatedResponse(BaseModel, Generic[T]):

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 
 import pytest
+from sqlalchemy import event
 from sqlmodel import Session
 
 from querymate import Querymate
@@ -12,6 +13,7 @@ from querymate.core.grouping import (
     GroupByConfig,
     GroupKeyExtractor,
 )
+from querymate.core.query_builder import QueryBuilder
 
 from .models import Post, User
 
@@ -267,6 +269,152 @@ class TestGroupedQueries:
         active_group = next(g for g in groups if g["key"] == "active")
         assert len(active_group["items"]) == 2
         assert active_group["pagination"]["total"] == 2
+
+    def test_window_grouping_matches_legacy_for_simple_field(
+        self, populated_db: Session, monkeypatch: pytest.MonkeyPatch
+    ):
+        legacy = Querymate(
+            select=["id", "name", "status"],
+            group_by="status",
+            sort=["id"],
+            limit=10,
+        ).run_grouped(populated_db, User, dialect="sqlite")
+
+        def fetch_for_group_fails(self, *args, **kwargs):
+            raise AssertionError("legacy per-group fetch should not run")
+
+        monkeypatch.setattr(QueryBuilder, "fetch_for_group", fetch_for_group_fails)
+
+        window = Querymate(
+            select=["id", "name", "status"],
+            group_by="status",
+            sort=["id"],
+            limit=10,
+            grouping={"strategy": "window"},
+        ).run_grouped(populated_db, User, dialect="sqlite")
+
+        assert window == legacy
+
+    def test_window_grouping_respects_per_group_limit(self, populated_db: Session):
+        querymate = Querymate(
+            select=["id", "name", "status"],
+            group_by="status",
+            sort=["id"],
+            grouping={"strategy": "window", "per_group_limit": 1},
+        )
+
+        result = querymate.run_grouped(populated_db, User, dialect="sqlite")
+
+        for group in result["groups"]:
+            assert len(group["items"]) <= 1
+        active_group = next(
+            group for group in result["groups"] if group["key"] == "active"
+        )
+        assert active_group["items"][0]["id"] == 1
+        assert active_group["pagination"]["total"] == 2
+
+    def test_window_grouping_respects_per_group_offset(self, populated_db: Session):
+        querymate = Querymate(
+            select=["id", "name", "status"],
+            group_by="status",
+            sort=["id"],
+            grouping={
+                "strategy": "window",
+                "per_group_limit": 1,
+                "per_group_offset": 1,
+            },
+        )
+
+        result = querymate.run_grouped(populated_db, User, dialect="sqlite")
+
+        active_group = next(
+            group for group in result["groups"] if group["key"] == "active"
+        )
+        assert [item["id"] for item in active_group["items"]] == [2]
+
+    def test_window_grouping_preserves_sort_order(self, populated_db: Session):
+        querymate = Querymate(
+            select=["id", "name", "status", "age"],
+            group_by="status",
+            sort=["-age"],
+            grouping={"strategy": "window"},
+        )
+
+        result = querymate.run_grouped(populated_db, User, dialect="sqlite")
+
+        for group in result["groups"]:
+            ages = [item["age"] for item in group["items"]]
+            assert ages == sorted(ages, reverse=True)
+
+    def test_window_grouping_without_counts_returns_has_next_and_avoids_count(
+        self, populated_db: Session
+    ):
+        statements: list[str] = []
+        bind = populated_db.get_bind()
+
+        def capture_sql(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement.lower())
+
+        event.listen(bind, "before_cursor_execute", capture_sql)
+        try:
+            querymate = Querymate(
+                select=["id", "name", "status"],
+                group_by="status",
+                sort=["id"],
+                grouping={
+                    "strategy": "window",
+                    "include_counts": False,
+                    "per_group_limit": 1,
+                },
+            )
+            result = querymate.run_grouped(populated_db, User, dialect="sqlite")
+        finally:
+            event.remove(bind, "before_cursor_execute", capture_sql)
+
+        active_group = next(
+            group for group in result["groups"] if group["key"] == "active"
+        )
+        assert active_group["pagination"]["total"] is None
+        assert active_group["pagination"]["pages"] is None
+        assert active_group["pagination"]["has_next_page"] is True
+        assert not any("count(" in statement for statement in statements)
+
+    def test_window_grouping_supports_date_grouping(self, populated_db: Session):
+        querymate = Querymate(
+            select=["id", "name", "created_at"],
+            group_by={"field": "created_at", "granularity": "month"},
+            grouping={"strategy": "window"},
+        )
+
+        result = querymate.run_grouped(populated_db, User, dialect="sqlite")
+
+        group_keys = [group["key"] for group in result["groups"]]
+        assert group_keys == ["2024-01", "2024-02", "2024-03"]
+
+    def test_window_grouping_falls_back_to_legacy_for_relationship_select(
+        self, populated_db: Session
+    ):
+        querymate = Querymate(
+            select=["id", "name", {"posts": ["id", "title"]}],
+            group_by="status",
+            grouping={"strategy": "window", "fallback": "legacy"},
+        )
+
+        result = querymate.run_grouped(populated_db, User, dialect="sqlite")
+
+        assert "groups" in result
+
+    def test_window_grouping_can_error_for_unsupported_shape(
+        self, populated_db: Session
+    ):
+        querymate = Querymate(
+            select=["id", "name", {"posts": ["id", "title"]}],
+            group_by="status",
+            grouping={"strategy": "window", "fallback": "error"},
+        )
+
+        with pytest.raises(ValueError, match="relationship select fields"):
+            querymate.run_grouped(populated_db, User, dialect="sqlite")
 
     def test_grouping_with_filter(self, populated_db: Session):
         """Test grouping with filter applied."""

--- a/tests/test_querymate.py
+++ b/tests/test_querymate.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.datastructures import QueryParams
+from pydantic import ValidationError
 from sqlalchemy import Engine
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -14,6 +15,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
+from querymate.core.query_builder import QueryBuilder
 from querymate.core.querymate import Querymate
 from tests.models import Post, User
 
@@ -667,6 +669,136 @@ def test_run_with_pagination_sync(db: Session) -> None:
     assert p.next_page == 2
 
 
+def test_run_with_pagination_full_mode_preserves_legacy_metadata(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    users = [
+        User(id=i, name=f"User {i}", is_active=True, email=f"u{i}@ex.com", age=20 + i)
+        for i in range(1, 4)
+    ]
+    db.add_all(users)
+    db.commit()
+
+    count_called = False
+    original_count = QueryBuilder.count
+
+    def count_spy(self: QueryBuilder, db: Session) -> int:
+        nonlocal count_called
+        count_called = True
+        return original_count(self, db)
+
+    monkeypatch.setattr(QueryBuilder, "count", count_spy)
+
+    q = Querymate(select=["id", "name"], limit=2, offset=0)
+    result = q.run_paginated(db, User)
+
+    assert count_called is True
+    assert result.pagination.model_dump() == {
+        "total": 3,
+        "page": 1,
+        "size": 2,
+        "pages": 2,
+        "previous_page": None,
+        "next_page": 2,
+    }
+
+
+def test_run_with_pagination_none_mode_skips_count(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    users = [
+        User(id=i, name=f"User {i}", is_active=True, email=f"u{i}@ex.com", age=20 + i)
+        for i in range(1, 4)
+    ]
+    db.add_all(users)
+    db.commit()
+
+    def count_fails(self: QueryBuilder, db: Session) -> int:
+        raise AssertionError("count should not run")
+
+    monkeypatch.setattr(QueryBuilder, "count", count_fails)
+
+    q = Querymate(
+        select=["id", "name"],
+        limit=2,
+        offset=0,
+        pagination={"mode": "none"},
+    )
+    result = q.run_paginated(db, User)
+
+    assert len(result.items) == 2
+    assert result.pagination.total is None
+    assert result.pagination.pages is None
+    assert result.pagination.has_next_page is None
+    assert result.pagination.mode == "none"
+
+
+def test_run_with_pagination_has_next_mode_fetches_extra_and_trims(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    users = [
+        User(id=i, name=f"User {i}", is_active=True, email=f"u{i}@ex.com", age=20 + i)
+        for i in range(1, 4)
+    ]
+    db.add_all(users)
+    db.commit()
+
+    def count_fails(self: QueryBuilder, db: Session) -> int:
+        raise AssertionError("count should not run")
+
+    monkeypatch.setattr(QueryBuilder, "count", count_fails)
+
+    q = Querymate(
+        select=["id", "name"],
+        sort=["id"],
+        limit=2,
+        offset=0,
+        pagination={"mode": "has_next"},
+    )
+    result = q.run_paginated(db, User)
+
+    assert [item["id"] for item in result.items] == [1, 2]
+    assert result.pagination.total is None
+    assert result.pagination.pages is None
+    assert result.pagination.has_next_page is True
+    assert result.pagination.next_page == 2
+    assert result.pagination.mode == "has_next"
+
+
+def test_run_with_pagination_has_next_mode_last_page(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    users = [
+        User(id=i, name=f"User {i}", is_active=True, email=f"u{i}@ex.com", age=20 + i)
+        for i in range(1, 4)
+    ]
+    db.add_all(users)
+    db.commit()
+
+    def count_fails(self: QueryBuilder, db: Session) -> int:
+        raise AssertionError("count should not run")
+
+    monkeypatch.setattr(QueryBuilder, "count", count_fails)
+
+    q = Querymate(
+        select=["id", "name"],
+        sort=["id"],
+        limit=2,
+        offset=2,
+        pagination={"mode": "has_next"},
+    )
+    result = q.run_paginated(db, User)
+
+    assert [item["id"] for item in result.items] == [3]
+    assert result.pagination.has_next_page is False
+    assert result.pagination.next_page is None
+
+
+def test_invalid_pagination_mode_has_clear_validation_error() -> None:
+    with pytest.raises(ValidationError, match="full"):
+        Querymate(pagination={"mode": "invalid"})
+
+
 def test_run_with_pagination_last_page_sync(db: Session) -> None:
     # Seed 7 users
     users = [
@@ -743,6 +875,36 @@ async def test_run_with_pagination_async(async_db: AsyncSession) -> None:
     assert p.page == 2
     assert p.previous_page == 1
     assert p.next_page == 3
+
+
+@pytest.mark.asyncio
+async def test_run_with_pagination_has_next_async_skips_count(
+    async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    users = [
+        User(id=i, name=f"A{i}", is_active=True, email=f"a{i}@ex.com", age=20 + i)
+        for i in range(1, 4)
+    ]
+    async_db.add_all(users)
+    await async_db.commit()
+
+    async def count_fails(self: QueryBuilder, db: AsyncSession) -> int:
+        raise AssertionError("count should not run")
+
+    monkeypatch.setattr(QueryBuilder, "count_async", count_fails)
+
+    q = Querymate(
+        select=["id", "name"],
+        sort=["id"],
+        limit=2,
+        offset=0,
+        pagination={"mode": "has_next"},
+    )
+    result = await q.run_async_paginated(async_db, User)
+
+    assert [item["id"] for item in result.items] == [1, 2]
+    assert result.pagination.has_next_page is True
+    assert result.pagination.total is None
 
 
 # ================================
@@ -903,7 +1065,9 @@ def test_join_type_in_querystring(db: Session) -> None:
 
     # Parse from query string
     query_params = QueryParams(
-        {"q": '{"select": ["id", "name", {"posts": ["id", "title"]}], "join_type": "left"}'}
+        {
+            "q": '{"select": ["id", "name", {"posts": ["id", "title"]}], "join_type": "left"}'
+        }
     )
     querymate = Querymate.from_qs(query_params)
 

--- a/tests/test_querymate.py
+++ b/tests/test_querymate.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncGenerator, Callable, Generator
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -17,7 +17,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from querymate.core.query_builder import QueryBuilder
-from querymate.core.querymate import Querymate
+from querymate.core.querymate import PaginationOptions, Querymate
 from tests.models import Post, User
 
 
@@ -733,7 +733,7 @@ def test_run_with_pagination_none_mode_skips_count(
         select=["id", "name"],
         limit=2,
         offset=0,
-        pagination={"mode": "none"},
+        pagination=PaginationOptions(mode="none"),
     )
     result = q.run_paginated(db, User)
 
@@ -764,7 +764,7 @@ def test_run_with_pagination_has_next_mode_fetches_extra_and_trims(
         sort=["id"],
         limit=2,
         offset=0,
-        pagination={"mode": "has_next"},
+        pagination=PaginationOptions(mode="has_next"),
     )
     result = q.run_paginated(db, User)
 
@@ -796,7 +796,7 @@ def test_run_with_pagination_has_next_mode_last_page(
         sort=["id"],
         limit=2,
         offset=2,
-        pagination={"mode": "has_next"},
+        pagination=PaginationOptions(mode="has_next"),
     )
     result = q.run_paginated(db, User)
 
@@ -807,7 +807,7 @@ def test_run_with_pagination_has_next_mode_last_page(
 
 def test_invalid_pagination_mode_has_clear_validation_error() -> None:
     with pytest.raises(ValidationError, match="full"):
-        Querymate(pagination={"mode": "invalid"})
+        Querymate(pagination=cast(Any, {"mode": "invalid"}))
 
 
 def test_run_with_pagination_last_page_sync(db: Session) -> None:
@@ -909,7 +909,7 @@ async def test_run_with_pagination_has_next_async_skips_count(
         sort=["id"],
         limit=2,
         offset=0,
-        pagination={"mode": "has_next"},
+        pagination=PaginationOptions(mode="has_next"),
     )
     result = await q.run_async_paginated(async_db, User)
 

--- a/tests/test_querymate.py
+++ b/tests/test_querymate.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncGenerator, Callable, Generator
+from datetime import datetime
 from typing import Any
 
 import pytest
@@ -103,6 +104,16 @@ def test_to_query_param() -> None:
         qp
         == "%7B%22select%22%3A%5B%22id%22%2C%22name%22%5D%2C%22filter%22%3A%7B%22age%22%3A%7B%22gt%22%3A25%7D%7D%2C%22sort%22%3A%5B%22-age%22%5D%2C%22limit%22%3A10%2C%22offset%22%3A0%2C%22include_pagination%22%3Afalse%2C%22group_by%22%3Anull%2C%22join_type%22%3Anull%7D"
     )
+
+
+def test_to_query_param_serializes_pydantic_json_values() -> None:
+    querymate = Querymate(
+        filter={"created_at": {"gte": datetime(2024, 1, 2, 3, 4, 5)}},
+    )
+
+    round_tripped = Querymate.from_query_param(querymate.to_query_param())
+
+    assert round_tripped.filter == {"created_at": {"gte": "2024-01-02T03:04:05"}}
 
 
 def test_from_qs() -> None:


### PR DESCRIPTION
## TL;DR
- Adds opt-in no-count pagination modes without changing default full pagination.
- Adds opt-in window grouped execution for simple/date grouped top-N use cases with legacy fallback.
- Documents rollout behavior and adds coverage for legacy and opt-in paths.

## Summary
- Added `pagination.mode`: `full` remains the default and still runs the count query, `none` fetches items only, and `has_next` fetches `limit + 1` then trims the extra row.
- Added `grouping` options for `strategy`, `include_counts`, `per_group_limit`, `per_group_offset`, and `fallback`.
- Added a window grouping strategy that uses one window-function query for supported simple model-field selections and simple/date group keys.
- Unsupported relationship selects, relationship group fields, and custom value sort dictionaries fall back to legacy by default or raise a clear error when `fallback` is `error`.
- Legacy request payload serialization and default grouped/paginated execution stay unchanged unless callers provide the new option blocks.
- Updated pagination/grouping docs and changelog entries.

## Flow
```mermaid
flowchart TD
    A[Querymate request] --> B{pagination.mode}
    B -->|full default| C[Fetch page and run count]
    B -->|none| D[Fetch page only]
    B -->|has_next| E[Fetch limit plus one and trim]
    A --> F{grouping.strategy}
    F -->|legacy default| G[Group keys plus per-group item queries]
    F -->|window opt-in| H{Supported shape}
    H -->|yes| I[Single window query for top N per group]
    H -->|no, fallback legacy| G
    H -->|no, fallback error| J[Clear validation error]
```

## Tests
- `uv run --python 3.13 ruff check querymate tests`
- `uv run --python 3.13 mypy querymate`
- `uv run --python 3.13 pytest -q`